### PR TITLE
Increase rewards MA, reset rewards for the new hotkey

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prompting"
-version = "2.19.9"
+version = "2.19.10"
 description = "Subnetwork 1 runs on Bittensor and is maintained by Macrocosmos. It's an effort to create decentralised AI"
 authors = ["Kalei Brady, Dmytro Bobrenko, Felix Quinque, Steffen Cruz, Richard Wardle"]
 readme = "README.md"

--- a/validator_api/chat_completion.py
+++ b/validator_api/chat_completion.py
@@ -237,7 +237,7 @@ async def chat_completion(
     uids: Optional[list[int]] = None,
     num_miners: int = 5,
     uid_tracker: UidTracker | None = None,
-    add_reliable_miners: int = 3,
+    add_reliable_miners: int = 0,
 ) -> tuple | StreamingResponse:
     # TODO: Add docstring.
     """Handle chat completion with multiple miners in parallel."""
@@ -252,7 +252,7 @@ async def chat_completion(
     primary_uids = filter_available_uids(
         task=body.get("task"), model=body.get("model"), test=shared_settings.API_TEST_MODE, n_miners=num_miners
     )
-    if uid_tracker is not None:
+    if uid_tracker is not None and add_reliable_miners > 0:
         # Add reliable uids, or ones with highest success rate to guarantee completed stream.
         reliable_uids = await uid_tracker.sample_reliable(
             task=TaskType.Inference, amount=add_reliable_miners, success_rate=0.99, add_random_extra=False


### PR DESCRIPTION
## Changes
  - Increase rewards MA from 24 to 36 epochs.
  - Reset rewards for the given UID if the hotkey was changed.
  - Remove reliable UID sampling by default for API.