### PR TITLE
Adjust sampling size, rewards MA

### DIFF
--- a/prompting/tasks/task_creation.py
+++ b/prompting/tasks/task_creation.py
@@ -18,7 +18,7 @@ RETRIES = 3
 class TaskLoop(AsyncLoopRunner):
     is_running: bool = False
     thread: threading.Thread = None
-    interval: int = 20
+    interval: int = 10
     task_queue: list | None = []
     scoring_queue: list | None = []
     miners_dict: dict | None = None

--- a/prompting/tasks/task_sending.py
+++ b/prompting/tasks/task_sending.py
@@ -16,7 +16,7 @@ from shared.timer import Timer
 
 shared_settings = settings.shared_settings
 
-NEURON_SAMPLE_SIZE = 100
+NEURON_SAMPLE_SIZE = 70
 
 
 def log_stream_results(stream_results):

--- a/prompting/weight_setting/weight_setter.py
+++ b/prompting/weight_setting/weight_setter.py
@@ -95,8 +95,8 @@ class WeightSetter(AsyncLoopRunner):
 
     # Rewards moving average persistency.
     reward_history_path: Path = Path("validator_rewards.jsonl")
-    # Rewards moving average, 36 epochs = approx. 12 hours.
-    reward_history_len: int = 36
+    # Rewards moving average, 28 epochs = approx. 10 hours.
+    reward_history_len: int = 28
     # List of uids info per epoch, e.g.: [{1: {"reward": 1.0, "hotkey": "ABC"}, 2: {"reward": 3.0, "hotkey": "XYZ"}}].
     reward_history: deque[dict[int, dict[str, float | str]]] | None = None
 
@@ -248,6 +248,7 @@ class WeightSetter(AsyncLoopRunner):
                 reward_dict[uid] += reward
 
         final_rewards = np.array(list(reward_dict.values())).astype(np.float32)
+
         return final_rewards
 
     @classmethod


### PR DESCRIPTION
## Changes
  - Reduce sampling size from 100 to 70.
  - Reduce rewards MA window from 36 to 28 epochs.
  - Increase task creation interval from 20 to 10 seconds delay.