### PR TITLE
use hotkey instead of axon in signature

### DIFF
--- a/apex/validator/miner_sampler.py
+++ b/apex/validator/miner_sampler.py
@@ -126,10 +126,10 @@ class MinerSampler:
 
         return miners_sample
 
-    async def query_miners(self, body: dict[str, Any], endpoint: str) -> str:
+    async def query_miners(self, body: dict[str, Any], endpoint: str, miner_hotkey: str) -> str:
         """Query the miners for the query."""
         body["signer"] = self._chain.wallet.hotkey.ss58_address
-        body["signed_for"] = endpoint
+        body["signed_for"] = miner_hotkey
         body["nonce"] = str(int(time.time()))
         try:
             async with aiohttp.ClientSession() as session:
@@ -154,7 +154,7 @@ class MinerSampler:
         for miner_info in miner_information:
             hotkeys.append(miner_info.hotkey)
             logger.debug(f"Querying miner generator at {miner_info.address} with uid: {miner_info.uid}")
-            tasks.append(self.query_miners(body=body, endpoint=miner_info.address))
+            tasks.append(self.query_miners(body=body, endpoint=miner_info.address, miner_hotkey=miner_info.hotkey))
         generator_results = await asyncio.gather(*tasks)
         return MinerGeneratorResults(query=query, generator_hotkeys=hotkeys, generator_results=generator_results)
 
@@ -193,7 +193,7 @@ class MinerSampler:
         tasks: list[Coroutine[str, str, Any]] = []
         for miner_info in miner_information:
             hotkeys.append(miner_info.hotkey)
-            tasks.append(self.query_miners(body=body, endpoint=miner_info.address))
+            tasks.append(self.query_miners(body=body, endpoint=miner_info.address, miner_hotkey=miner_info.hotkey))
         discriminator_results = await asyncio.gather(*tasks)
 
         # Parse discriminator results and calculate scores


### PR DESCRIPTION
Use miner's hotkey instead of axon url for creating signature.
Attackers could set same axon with other miner's.